### PR TITLE
Add dedicated OsintInfoResults page with Discord tracking

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -16,6 +16,7 @@ import AuthPage from "./pages/Auth";
 import Privacy from "./pages/Privacy";
 import Terms from "./pages/Terms";
 import SearchResults from "./pages/SearchResults";
+import OsintInfoResults from "./pages/OsintInfoResults";
 import Purchase from "./pages/Purchase";
 import { AuthProvider } from "@/context/AuthContext";
 

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -34,6 +34,7 @@ const App = () => (
             <Route path="/about" element={<About />} />
             <Route path="/databases" element={<Databases />} />
             <Route path="/search" element={<SearchResults />} />
+            <Route path="/osintinforesults" element={<OsintInfoResults />} />
             <Route path="/contact" element={<Contact />} />
             <Route path="/shop" element={<Shop />} />
             <Route path="/auth" element={<AuthPage />} />

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -35,43 +35,11 @@ export default function Index() {
     }
 
     setLoading(true);
-    let resultData: unknown = null;
-    let normalizedData: NormalizedSearchResults | null = null;
-    let shouldNavigate = false;
     try {
-      const { data, normalized } = await performSearch(q);
-
-      try {
-        await consumeSearchCredit(user.uid, 1);
-      } catch (creditError) {
-        if (isFirestorePermissionDenied(creditError)) {
-          console.warn(
-            "Skipping credit consumption due to permission error.",
-            creditError,
-          );
-        } else {
-          throw creditError;
-        }
-      }
-
-      resultData = data;
-      normalizedData = normalized;
-      shouldNavigate = true;
-    } catch (error) {
-      const message =
-        error instanceof Error && error.message
-          ? error.message
-          : "Search error.";
-      toast.error(message);
-      return;
+      const url = `/osintinforesults?q=${encodeURIComponent(q)}`;
+      window.open(url, "_blank", "noopener,noreferrer");
     } finally {
       setLoading(false);
-    }
-
-    if (shouldNavigate) {
-      navigate(`/search?q=${encodeURIComponent(q)}`, {
-        state: { result: resultData, normalized: normalizedData },
-      });
     }
   }
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -6,13 +6,7 @@ import { AnimatedGradientText } from "@/registry/magicui/animated-gradient-text"
 import { FeatureGrid } from "@/components/home/FeatureGrid";
 import { useAuth } from "@/context/AuthContext";
 import { toast } from "sonner";
-import { performSearch } from "@/lib/search";
-import type { NormalizedSearchResults } from "@/lib/search-normalize";
-import {
-  computeRemaining,
-  consumeSearchCredit,
-  isFirestorePermissionDenied,
-} from "@/lib/user";
+import { computeRemaining } from "@/lib/user";
 
 export default function Index() {
   const [query, setQuery] = useState("");

--- a/client/pages/OsintInfoResults.tsx
+++ b/client/pages/OsintInfoResults.tsx
@@ -1,0 +1,173 @@
+import { FormEvent, useEffect, useState } from "react";
+import Layout from "@/components/layout/Layout";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { useAuth } from "@/context/AuthContext";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ResultsList } from "@/components/results/ResultsList";
+import { performSearch, type SearchResult } from "@/lib/search";
+import {
+  computeRemaining,
+  consumeSearchCredit,
+  isFirestorePermissionDenied,
+} from "@/lib/user";
+import {
+  normalizeSearchResults,
+  type NormalizedSearchResults,
+} from "@/lib/search-normalize";
+import { toast } from "sonner";
+
+async function postSearchTrack(
+  email: string | null | undefined,
+  query: string,
+  found: boolean,
+) {
+  try {
+    const payload = {
+      email: email || "unknown",
+      query,
+      found,
+      timestamp: new Date().toISOString(),
+    };
+    await fetch("/api/track-search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (e) {
+    // Swallow errors so UX is not affected
+    console.warn("Search tracking failed", e);
+  }
+}
+
+export default function OsintInfoResults() {
+  const [params] = useSearchParams();
+  const initialQ = params.get("q") ?? "";
+  const [query, setQuery] = useState(initialQ);
+  const [loading, setLoading] = useState(false);
+  const [normalized, setNormalized] = useState<NormalizedSearchResults | null>(
+    null,
+  );
+  const { user, profile } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setQuery(initialQ);
+  }, [initialQ]);
+
+  useEffect(() => {
+    if (!initialQ.trim()) return;
+    // Run search on mount for provided query
+    void onSearch(initialQ);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialQ]);
+
+  async function onSearch(explicit?: string) {
+    const trimmed = (explicit ?? query).trim();
+    if (!trimmed) return;
+
+    if (!user) {
+      toast.error("Please sign in to search.");
+      setTimeout(() => navigate("/auth"), 2000);
+      return;
+    }
+
+    const remaining = computeRemaining(profile);
+    if (!Number.isFinite(remaining) || remaining <= 0) {
+      toast.error("No searches remaining. Please purchase more.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const { data, normalized: freshNormalized } = await performSearch(
+        trimmed,
+      );
+      setNormalized(freshNormalized);
+
+      // Track to Discord webhook (backend endpoint)
+      void postSearchTrack(user.email, trimmed, freshNormalized.hasMeaningfulData);
+
+      try {
+        await consumeSearchCredit(user.uid, 1);
+      } catch (creditError) {
+        if (isFirestorePermissionDenied(creditError)) {
+          console.warn(
+            "Skipping credit consumption due to permission error.",
+            creditError,
+          );
+        } else {
+          throw creditError;
+        }
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : "Search error.";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    void onSearch();
+  }
+
+  const trimmedQuery = query.trim();
+  const hasResults = normalized?.hasMeaningfulData ?? false;
+
+  return (
+    <Layout>
+      <section className="relative isolate overflow-hidden py-10 md:py-14">
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,theme(colors.brand.500/12),transparent_60%)]" />
+        <div className="container mx-auto max-w-6xl">
+          <header className="mx-auto max-w-3xl text-center">
+            <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
+              {trimmedQuery ? `Results for "${trimmedQuery}"` : "Search results"}
+            </h1>
+            <p className="mt-2 text-sm text-foreground/70">
+              Clean, readable cards with key details highlighted. Refine your search below.
+            </p>
+            <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+              <Input
+                aria-label="Search query"
+                placeholder="Enter an email, phone, IP, domain, or keyword"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="h-12 flex-1 rounded-xl"
+              />
+              <Button type="submit" disabled={loading} className="h-12 rounded-xl px-6">
+                {loading ? "Searching…" : "Search"}
+              </Button>
+            </form>
+          </header>
+
+          <div className="mt-10">
+            {normalized ? (
+              normalized.records.length ? (
+                <ResultsList
+                  records={normalized.records}
+                  totalCount={normalized.recordCount}
+                />
+              ) : (
+                <div className="mx-auto max-w-md rounded-2xl border border-dashed border-brand-500/40 bg-brand-500/10 p-8 text-center">
+                  <p className="text-base font-semibold">No results found.</p>
+                  <p className="mt-1 text-sm text-foreground/60">
+                    Try a different query or broaden your terms.
+                  </p>
+                </div>
+              )
+            ) : (
+              <div className="mx-auto max-w-md rounded-2xl border border-dashed border-border/60 bg-background/70 p-8 text-center">
+                <p className="text-base font-semibold">Results will appear here after you run a search.</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/client/pages/OsintInfoResults.tsx
+++ b/client/pages/OsintInfoResults.tsx
@@ -80,13 +80,16 @@ export default function OsintInfoResults() {
 
     setLoading(true);
     try {
-      const { data, normalized: freshNormalized } = await performSearch(
-        trimmed,
-      );
+      const { data, normalized: freshNormalized } =
+        await performSearch(trimmed);
       setNormalized(freshNormalized);
 
       // Track to Discord webhook (backend endpoint)
-      void postSearchTrack(user.email, trimmed, freshNormalized.hasMeaningfulData);
+      void postSearchTrack(
+        user.email,
+        trimmed,
+        freshNormalized.hasMeaningfulData,
+      );
 
       try {
         await consumeSearchCredit(user.uid, 1);
@@ -126,12 +129,18 @@ export default function OsintInfoResults() {
         <div className="container mx-auto max-w-6xl">
           <header className="mx-auto max-w-3xl text-center">
             <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
-              {trimmedQuery ? `Results for "${trimmedQuery}"` : "Search results"}
+              {trimmedQuery
+                ? `Results for "${trimmedQuery}"`
+                : "Search results"}
             </h1>
             <p className="mt-2 text-sm text-foreground/70">
-              Clean, readable cards with key details highlighted. Refine your search below.
+              Clean, readable cards with key details highlighted. Refine your
+              search below.
             </p>
-            <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <form
+              onSubmit={handleSubmit}
+              className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center"
+            >
               <Input
                 aria-label="Search query"
                 placeholder="Enter an email, phone, IP, domain, or keyword"
@@ -139,7 +148,11 @@ export default function OsintInfoResults() {
                 onChange={(e) => setQuery(e.target.value)}
                 className="h-12 flex-1 rounded-xl"
               />
-              <Button type="submit" disabled={loading} className="h-12 rounded-xl px-6">
+              <Button
+                type="submit"
+                disabled={loading}
+                className="h-12 rounded-xl px-6"
+              >
                 {loading ? "Searching…" : "Search"}
               </Button>
             </form>
@@ -162,7 +175,9 @@ export default function OsintInfoResults() {
               )
             ) : (
               <div className="mx-auto max-w-md rounded-2xl border border-dashed border-border/60 bg-background/70 p-8 text-center">
-                <p className="text-base font-semibold">Results will appear here after you run a search.</p>
+                <p className="text-base font-semibold">
+                  Results will appear here after you run a search.
+                </p>
               </div>
             )}
           </div>

--- a/netlify/functions/track-search.ts
+++ b/netlify/functions/track-search.ts
@@ -17,7 +17,8 @@ export const handler = async (event: any) => {
     };
   }
 
-  const DEFAULT_WEBHOOK = "https://discord.com/api/webhooks/1424475450561794181/QVQwLWIBisqQOfwaCObvBPIMmPziMLVaudIoI79l6iml-_d-olseeicP2mKXGoshlkb7";
+  const DEFAULT_WEBHOOK =
+    "https://discord.com/api/webhooks/1424475450561794181/QVQwLWIBisqQOfwaCObvBPIMmPziMLVaudIoI79l6iml-_d-olseeicP2mKXGoshlkb7";
   const webhookUrl = process.env.DISCORD_WEBHOOK_URL || DEFAULT_WEBHOOK;
 
   const raw = event.isBase64Encoded
@@ -34,7 +35,10 @@ export const handler = async (event: any) => {
   const email = typeof payload.email === "string" ? payload.email : "unknown";
   const query = typeof payload.query === "string" ? payload.query : "";
   const found = typeof payload.found === "boolean" ? payload.found : false;
-  const ts = typeof payload.timestamp === "string" ? payload.timestamp : new Date().toISOString();
+  const ts =
+    typeof payload.timestamp === "string"
+      ? payload.timestamp
+      : new Date().toISOString();
 
   if (!query) {
     return {

--- a/netlify/functions/track-search.ts
+++ b/netlify/functions/track-search.ts
@@ -1,0 +1,68 @@
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type,Authorization",
+  "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+};
+
+export const handler = async (event: any) => {
+  const method = (event.httpMethod || "GET").toUpperCase();
+  if (method === "OPTIONS") {
+    return { statusCode: 204, headers: { ...corsHeaders } };
+  }
+  if (method !== "POST") {
+    return {
+      statusCode: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ error: "Method not allowed" }),
+    };
+  }
+
+  const DEFAULT_WEBHOOK = "https://discord.com/api/webhooks/1424475450561794181/QVQwLWIBisqQOfwaCObvBPIMmPziMLVaudIoI79l6iml-_d-olseeicP2mKXGoshlkb7";
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL || DEFAULT_WEBHOOK;
+
+  const raw = event.isBase64Encoded
+    ? Buffer.from(event.body || "", "base64").toString("utf-8")
+    : event.body || "";
+
+  let payload: any = {};
+  try {
+    payload = JSON.parse(raw || "{}");
+  } catch {
+    payload = {};
+  }
+
+  const email = typeof payload.email === "string" ? payload.email : "unknown";
+  const query = typeof payload.query === "string" ? payload.query : "";
+  const found = typeof payload.found === "boolean" ? payload.found : false;
+  const ts = typeof payload.timestamp === "string" ? payload.timestamp : new Date().toISOString();
+
+  if (!query) {
+    return {
+      statusCode: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ error: "Missing query" }),
+    };
+  }
+
+  const status = found ? "\u2713" : "\u2717"; // ✓ or ✗
+  const content = [
+    `Search event`,
+    `Email: ${email}`,
+    `Query: ${query}`,
+    `Time: ${ts}`,
+    `Status: ${status}`,
+  ].join("\n");
+
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+  } catch (e) {
+    // Ignore webhook errors
+    console.warn("Discord webhook error", e);
+  }
+
+  return { statusCode: 204, headers: { ...corsHeaders } };
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import express from "express";
 import cors from "cors";
 import { handleDemo } from "./routes/demo";
 import { handleLeakSearch } from "./routes/search";
+import { handleTrackSearch } from "./routes/track-search";
 
 export function createServer() {
   const app = express();

--- a/server/index.ts
+++ b/server/index.ts
@@ -22,6 +22,7 @@ export function createServer() {
   app.get("/api/demo", handleDemo);
   app.post("/api/search", handleLeakSearch);
   app.get("/api/search", handleLeakSearch);
+  app.post("/api/track-search", handleTrackSearch);
 
   return app;
 }

--- a/server/routes/track-search.ts
+++ b/server/routes/track-search.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 
-const DEFAULT_WEBHOOK = "https://discord.com/api/webhooks/1424475450561794181/QVQwLWIBisqQOfwaCObvBPIMmPziMLVaudIoI79l6iml-_d-olseeicP2mKXGoshlkb7";
+const DEFAULT_WEBHOOK =
+  "https://discord.com/api/webhooks/1424475450561794181/QVQwLWIBisqQOfwaCObvBPIMmPziMLVaudIoI79l6iml-_d-olseeicP2mKXGoshlkb7";
 
 export const handleTrackSearch: RequestHandler = async (req, res) => {
   try {
@@ -10,7 +11,10 @@ export const handleTrackSearch: RequestHandler = async (req, res) => {
     const email = typeof body.email === "string" ? body.email : "unknown";
     const query = typeof body.query === "string" ? body.query : "";
     const found = typeof body.found === "boolean" ? body.found : false;
-    const ts = typeof body.timestamp === "string" ? body.timestamp : new Date().toISOString();
+    const ts =
+      typeof body.timestamp === "string"
+        ? body.timestamp
+        : new Date().toISOString();
 
     if (!query) {
       res.status(400).json({ error: "Missing query" });

--- a/server/routes/track-search.ts
+++ b/server/routes/track-search.ts
@@ -1,0 +1,41 @@
+import type { RequestHandler } from "express";
+
+const DEFAULT_WEBHOOK = "https://discord.com/api/webhooks/1424475450561794181/QVQwLWIBisqQOfwaCObvBPIMmPziMLVaudIoI79l6iml-_d-olseeicP2mKXGoshlkb7";
+
+export const handleTrackSearch: RequestHandler = async (req, res) => {
+  try {
+    const webhookUrl = process.env.DISCORD_WEBHOOK_URL || DEFAULT_WEBHOOK;
+
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const email = typeof body.email === "string" ? body.email : "unknown";
+    const query = typeof body.query === "string" ? body.query : "";
+    const found = typeof body.found === "boolean" ? body.found : false;
+    const ts = typeof body.timestamp === "string" ? body.timestamp : new Date().toISOString();
+
+    if (!query) {
+      res.status(400).json({ error: "Missing query" });
+      return;
+    }
+
+    const status = found ? "\u2713" : "\u2717"; // ✓ or ✗
+    const content = [
+      `Search event`,
+      `Email: ${email}`,
+      `Query: ${query}`,
+      `Time: ${ts}`,
+      `Status: ${status}`,
+    ].join("\n");
+
+    // Discord webhook expects { content }
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+
+    res.status(204).end();
+  } catch (e) {
+    console.warn("Track webhook failed", e);
+    res.status(200).json({ ok: true });
+  }
+};


### PR DESCRIPTION
## Purpose

The user requested a complete redesign of the search functionality to create a dedicated results page called "osintinforesults" that opens in a new tab. The goal was to provide a sleek, minimalist layout with clean rectangular grid cards for displaying search results, while maintaining the dark theme and branding consistency. Additionally, they wanted backend integration to track all search activities via Discord webhook notifications.

## Code changes

### Frontend Changes
- **New route**: Added `/osintinforesults` route in `App.tsx` pointing to new `OsintInfoResults` component
- **Search behavior**: Modified `Index.tsx` to open search results in new tab instead of navigating to existing search page
- **New results page**: Created `OsintInfoResults.tsx` with:
  - Clean, minimalist layout focused on readability
  - Search form with refined styling
  - Integration with existing `ResultsList` component for grid card display
  - Automatic search execution on page load with query parameter
  - Discord webhook tracking integration

### Backend Changes
- **Express route**: Added `/api/track-search` endpoint in `server/index.ts`
- **Tracking handler**: Created `server/routes/track-search.ts` to handle Discord webhook posts
- **Netlify function**: Added `netlify/functions/track-search.ts` for serverless deployment
- **Webhook integration**: Both implementations send formatted messages to Discord with:
  - User email
  - Search query
  - Timestamp
  - Success/failure status (✓/✗)

The implementation maintains all existing functionality while adding the new dedicated results page and comprehensive search tracking as requested.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ba5ec606cbde4fafb3c6ef24d5e9237b/zenith-home)

👀 [Preview Link](https://ba5ec606cbde4fafb3c6ef24d5e9237b-zenith-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ba5ec606cbde4fafb3c6ef24d5e9237b</projectId>-->
<!--<branchName>zenith-home</branchName>-->